### PR TITLE
Fix server-side loading importing client-side only libraries

### DIFF
--- a/src/main/java/net/crumbs/createcobblemon/CreateCobblemonIndustrializedClient.java
+++ b/src/main/java/net/crumbs/createcobblemon/CreateCobblemonIndustrializedClient.java
@@ -1,11 +1,11 @@
 package net.crumbs.createcobblemon;
 
 import net.fabricmc.api.ClientModInitializer;
-import net.crumbs.createcobblemon.fluids.ModFluids;
+import net.crumbs.createcobblemon.fluids.ModFluidsClient;
 
 public class CreateCobblemonIndustrializedClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
-        ModFluids.onInitializeClient();
+        ModFluidsClient.onInitializeClient();
     }
 }

--- a/src/main/java/net/crumbs/createcobblemon/fluids/ModFluids.java
+++ b/src/main/java/net/crumbs/createcobblemon/fluids/ModFluids.java
@@ -1,8 +1,6 @@
 package net.crumbs.createcobblemon.fluids;
 
 import net.crumbs.createcobblemon.CreateCobblemonIndustrialized;
-import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
-import net.fabricmc.fabric.api.client.render.fluid.v1.SimpleFluidRenderHandler;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
@@ -28,93 +26,6 @@ public class ModFluids {
 
     public static void registerModFluids() {
         CreateCobblemonIndustrialized.LOGGER.info("Registering Mod Fluids for " + CreateCobblemonIndustrialized.MOD_ID);
-    }
-
-
-    public static void onInitializeClient() {
-        // This entrypoint is suitable for setting up client-specific logic, such as rendering.
-        CreateCobblemonIndustrialized.LOGGER.info("Registering Clientside Fluid rendering for " + CreateCobblemonIndustrialized.MOD_ID);
-
-        FluidRenderHandlerRegistry.INSTANCE.register(MEDICINAL_BREW,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0x2ebca2
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(ETHER,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0xd8a8e0
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(ELIXIR,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0xf1b097
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(POTION,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0xab90ce
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(HYPER_POTION,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0xf59bdd
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(FULL_HEAL,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0xf7ef3f
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(ANTIDOTE,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0xfffa8d
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(AWAKENING,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0x92faff
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(BURN_HEAL,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0x97ffb8
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(ICE_HEAL,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0xffd0cc
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(PARALYZE_HEAL,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0xedff7a
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(MAX_ETHER,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0xb9f197
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(MAX_ELIXIR,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0x97f1e4
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(SUPER_POTION,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0xe1978d
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(MAX_POTION,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0x869eee
-        ));
-        FluidRenderHandlerRegistry.INSTANCE.register(FULL_RESTORE,new SimpleFluidRenderHandler(
-                new Identifier("minecraft:block/water_still"),
-                new Identifier("minecraft:block/water_flow"),
-                0x9bd77f
-        ));
     }
 
     public static Identifier asResource(String id){

--- a/src/main/java/net/crumbs/createcobblemon/fluids/ModFluidsClient.java
+++ b/src/main/java/net/crumbs/createcobblemon/fluids/ModFluidsClient.java
@@ -1,0 +1,97 @@
+package net.crumbs.createcobblemon.fluids;
+
+import net.crumbs.createcobblemon.CreateCobblemonIndustrialized;
+import net.fabricmc.fabric.api.client.render.fluid.v1.FluidRenderHandlerRegistry;
+import net.fabricmc.fabric.api.client.render.fluid.v1.SimpleFluidRenderHandler;
+import net.minecraft.util.Identifier;
+
+public class ModFluidsClient {
+
+
+    public static void onInitializeClient() {
+        // This entrypoint is suitable for setting up client-specific logic, such as rendering.
+        CreateCobblemonIndustrialized.LOGGER.info("Registering Clientside Fluid rendering for " + CreateCobblemonIndustrialized.MOD_ID);
+
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.MEDICINAL_BREW,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0x2ebca2
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.ETHER,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0xd8a8e0
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.ELIXIR,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0xf1b097
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.POTION,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0xab90ce
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.HYPER_POTION,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0xf59bdd
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.FULL_HEAL,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0xf7ef3f
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.ANTIDOTE,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0xfffa8d
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.AWAKENING,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0x92faff
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.BURN_HEAL,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0x97ffb8
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.ICE_HEAL,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0xffd0cc
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.PARALYZE_HEAL,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0xedff7a
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.MAX_ETHER,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0xb9f197
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.MAX_ELIXIR,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0x97f1e4
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.SUPER_POTION,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0xe1978d
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.MAX_POTION,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0x869eee
+        ));
+        FluidRenderHandlerRegistry.INSTANCE.register(ModFluids.FULL_RESTORE,new SimpleFluidRenderHandler(
+                new Identifier("minecraft:block/water_still"),
+                new Identifier("minecraft:block/water_flow"),
+                0x9bd77f
+        ));
+    }
+
+}


### PR DESCRIPTION
As described in issue #3. Shared and client-side only code were in the same class for fluids, and caused issues with attempting to load client-side only libraries in server environments. A client-side only class for fluids has been created, leaving the shared code in the old class, and now the server should only load the shared code and not the client-side only code.